### PR TITLE
fix: message payload to job params

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,39 @@ To add additional sources, click the **Add** button. To remove a source, click t
 
 Finally, click the **Save** button at the bottom of the form to save the settings. Once these settings are saved, a new connection to each server will be established and a listener will wait for messages.
 
+At AMQP message payload you can pass a JSONArray with the parameters to be mapped to the job
+parameters. The format is the following:
+
+```json
+[
+    {
+        "name": "PARAM1",
+        "value": "Value for PARAM1"
+    },
+    {
+        "name": "OTHER_PARAM",
+        "value": "Value for OTHER_PARAM"
+    }
+]
+```
+
+With that AMQP message payload, if the job to be triggered has the parameters `PARAM1` and `OTHER_PARAM`, then
+the parameters will be mapped whit the payload values.
+
+## Development
+You can modify this plugin easely into a Docker container with JDK and Maven. Just open a bash into 
+your container:
+
+```sh
+docker run -it --rm --platform=linux/amd64 -v $PWD:/work -w /work -p 8080:8080 -v maven:/root/.m2/ maven:3.9.6-eclipse-temurin-17 bash
+```
+
+Validate the code with `mvn validate`
+
+Test your plugin changes into an embebed Jenkins with `mvn hpi:run`, [more info](https://www.jenkins.io/doc/developer/tutorial/run/). TODO: fix
+
+Build your hpi to be installed onto your Jenkins with `mvn hpi:hpi`, [more info](https://jenkinsci.github.io/maven-hpi-plugin/).`
+
 **NOTE:** If you have the `qpid-cpp-client-devel` package installed, it is possible to test a configuration by quickly sending a trigger message using `qpid-send` through a broker as follows (and to which the trigger must be configured to listen):
 ```
 qpid-send [-b <broker-url>] -a <queue-name> -m1

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.26</version>
+        <version>4.78</version>
         <relativePath />
     </parent>
     <groupId>io.jenkins.plugins</groupId>
@@ -12,7 +12,7 @@
     <version>1.1-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <properties>
-        <jenkins.version>2.7.3</jenkins.version>
+        <jenkins.version>2.440</jenkins.version>
         <java.level>8</java.level>
     </properties>
     <name>AMQP Build Trigger Plugin</name>
@@ -40,7 +40,7 @@
     <repositories>
         <repository>
             <id>repo.jenkins-ci.org</id>
-            <url>https://repo.jenkins-ci.org/public/</url>
+            <url>https://repo.jenkins-ci.org/releases/</url>
         </repository>
     </repositories>
     <pluginRepositories>
@@ -49,6 +49,18 @@
             <url>https://repo.jenkins-ci.org/public/</url>
         </pluginRepository>
     </pluginRepositories>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.jenkins-ci.main</groupId>
+                <artifactId>jenkins-bom</artifactId>
+                <version>2.447</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <dependencies>
     	<dependency>
     		<groupId>org.apache.commons</groupId>

--- a/src/main/java/com/redhat/jenkins/plugins/amqpbuildtrigger/AmqpMessageListener.java
+++ b/src/main/java/com/redhat/jenkins/plugins/amqpbuildtrigger/AmqpMessageListener.java
@@ -5,6 +5,7 @@ import java.util.logging.Logger;
 
 import javax.jms.Message;
 import javax.jms.MessageListener;
+import javax.jms.BytesMessage;
 
 public class AmqpMessageListener implements MessageListener {
 
@@ -23,10 +24,24 @@ public class AmqpMessageListener implements MessageListener {
             LOGGER.info("Message received on broker " + brokerParams.toString() + "; msg=" + message.toString());
             for (AmqpBuildTrigger t : triggers) {
                 LOGGER.info("Remote build triggered: " + t.getProjectName());
-                t.scheduleBuild(brokerParams.toString(), null);
+                t.scheduleBuild(brokerParams.toString(), getMessageContent(message));
             }
         } catch (Exception e) {
             LOGGER.warning("Exception thrown in RemoteBuildListener.onMessage(): " + e.getMessage());
         }
+    }
+    // method if message is a BytesMessage, then convert it to a String
+    private String getMessageContent(Message message) {
+        if (message instanceof BytesMessage) {
+            try {
+                BytesMessage bytesMessage = (BytesMessage) message;
+                byte[] bytes = new byte[(int) bytesMessage.getBodyLength()];
+                bytesMessage.readBytes(bytes);
+                return new String(bytes, "UTF-8");
+            } catch (Exception e) {
+                LOGGER.warning("Exception thrown in RemoteBuildListener.getMessageContent(): " + e.getMessage());
+            }
+        }
+        return message.toString();
     }
 }


### PR DESCRIPTION
Fix to pass the message payload into the job parameters and been able to run the job with parameters from the AMQP message.

### Testing done
Running the `mvn hpi:run` and tested against a RabbitMQ with AMQP1.0 support.
